### PR TITLE
Adding ability to enable misspellings [WIP]

### DIFF
--- a/performance.js
+++ b/performance.js
@@ -7,20 +7,40 @@ var TrieSearch = require('./src/TrieSearch');
 var dict = require('./dictionary.json');
 var util = require('util');
 
+var lookups = ['a','e', 's', 't', 'ab', 'de', 'th', 'sh', 'ch', 'up', 'and', 'pre', 'post'];
 
-count = 0;
-for (var key in dict)
-count++;
-console.log('Dictionary loaded from JSON. Entries: ', count);
-var memStart = process.memoryUsage().heapTotal / 1048576;
-console.log('Memory: ' + memStart + ' MB');
-var ts = new TrieSearch();
-ts.addFromObject(dict);
+function run(options) {
+  count = 0;
+  for (var key in dict)
+    count++;
 
-console.log('Dictionary loaded into TrieSearch.');
-console.log('Sample of \'android\'', ts.get('android'));
+  var timeStart = new Date().getTime();
+  var memStart = process.memoryUsage().heapTotal / 1048576;
+  var ts = new TrieSearch(options);
+  ts.addFromObject(dict);
 
-console.log('Trie Node Count: ', ts.size);
+  console.log('\tSearch Items Added: ', count);
+  console.log('\tTrie Node Count: ', ts.size);
 
-var memEnd = process.memoryUsage().heapTotal / 1048576;
-console.log('Trie Memory Used: ' + (memEnd - memStart) + ' MB');
+  var time = new Date().getTime() - timeStart;
+  var memEnd = process.memoryUsage().heapTotal / 1048576;
+  console.log('\tTrie Memory Used: ' + (memEnd - memStart) + ' MB');
+  console.log('\tTime spent Inserting (ms)', time);
+
+  timeStart = new Date().getTime();
+
+  for (var i = 0; i < lookups.length; i++) {
+    ts.get(lookups[i]);
+  }
+
+  time = new Date().getTime() - timeStart;
+  console.log('\tTime spent retrieving (ms)', time);
+}
+
+console.log('-------------- Running enableMisspellings=false --------------');
+run();
+
+console.log('-------------- Running enableMisspellings=true --------------');
+run({
+  enableMisspellings: true
+});

--- a/test/TrieSearchTest.js
+++ b/test/TrieSearchTest.js
@@ -13,7 +13,7 @@ describe('TrieSearch', function() {
       assert.equal(ts.keyFields.length, 1);
     });
   });
-  
+
   describe('new TrieSearch(keyFields).keyToArr should work', function() {
     it('\'key\' -> [\'k\', \'e\', \'y\']', function() {
       var ts = new TrieSearch();
@@ -27,7 +27,7 @@ describe('TrieSearch', function() {
       assert.equal(ts.keyToArr('key')[0], 'ke');
       assert.equal(ts.keyToArr('key')[1], 'y');
     });
-    
+
     it('for options.min == 2, \'keyset\' -> [\'ke\', \'y\', \'s\', \'e\', \'t\']', function() {
       var ts = new TrieSearch('blah', {min: 2});
       assert.equal(ts.keyToArr('keyset')[0], 'ke');
@@ -95,7 +95,7 @@ describe('TrieSearch', function() {
       assert.equal(ts.get('cat')[0], items[2]);
     });
   });
-  
+
   describe('TrieSearch::add(...) and TrieSearch::get(...) should work for a single item with a numeric key', function() {
     var ts = new TrieSearch('key'),
       item = {key: 1234567890};
@@ -121,7 +121,7 @@ describe('TrieSearch', function() {
       assert.equal(ts.get('nope').length, 0);
     });
   });
-  
+
   describe('TrieSearch::add(...) and TrieSearch::get(...) should work for a single item with no split and whitespace', function() {
     var ts = new TrieSearch('key', {
         splitOnRegEx: false
@@ -167,36 +167,36 @@ describe('TrieSearch', function() {
     it('get(\'the quick\') should return all entries', function() {
       assert(ts.get('the quick').length == 3);
     });
-    
+
     it('get(\'the brown\') should return 2 entries', function() {
       assert(ts.get('the brown').length == 2);
     });
-    
+
     it('get(\'the fox\') should return 3 entries', function() {
       assert(ts.get('the fox').length == 3);
     });
-    
+
     it('get(\'fox brown\') should return 1 entry', function() {
       assert(ts.get('fox brown').length == 1);
     });
-    
+
     it('get(\'brown fox\') should return 1 entry', function() {
       assert(ts.get('brown fox').length == 1);
     });
-    
+
     it('get(\'brown f\') should return 2 entry, ignoring the shortness of the second word', function() {
       assert(ts.get('brown f').length == 2);
     });
-    
+
     it('get(\'br f\') should return 1 entry, ignoring the shortness of the second word', function() {
       assert(ts.get('br f').length == 2);
     });
-    
+
     it('get(\'qui b c d e f g h\') should return 3 entries, ignoring the shortness of all subsequent words', function() {
       assert(ts.get('qui b c d e f g h').length == 3);
     });
   });
-  
+
   describe('TrieSearch::get(...) should work for array of phrases', function() {
     var ts = new TrieSearch('key', {min: 2}),
       item1 = {key: 'the quick brown fox'},
@@ -213,7 +213,7 @@ describe('TrieSearch', function() {
       assert(ts.get(['the brown', 'quick']).length == 3);
     });
   });
-  
+
   describe('TrieSearch::get(...) should work with cache==true', function() {
     var ts = new TrieSearch('key', {min: 2}),
       item1 = {key: 'the quick brown fox'},
@@ -229,19 +229,19 @@ describe('TrieSearch', function() {
     it('_get() should return identical array for the same request', function() {
       var f1 = ts._get('the brown'),
         f2 = ts._get('the brown');
-      
+
       assert(f1 === f2, 'was not the same array.');
     });
-    
+
     it('_get() should clear cache when clearCache() is called', function() {
       var f1 = ts._get('the brown');
       ts.clearCache();
       var f2 = ts._get('the brown');
-      
+
       assert(f1 !== f2, 'cache was not cleared.');
     });
   });
-  
+
   describe('TrieSearch::get(...) should work with cache==true and maxCacheSize == X', function() {
     var ts = new TrieSearch('key', {
         min: 2,
@@ -265,11 +265,11 @@ describe('TrieSearch', function() {
       ts._get('the fox');
       assert(ts.getCache.all.length == 2, 'Cache size was not size 2 (the fox).'); // Should remain at 2.
       var f2 = ts._get('the brown'); // This should return different array.
-      
+
       assert(f1 !== f2, 'cache did not clear out old value!');
     });
   });
-  
+
   describe('TrieSearch::get(...) should work with cache==false', function() {
     var ts = new TrieSearch('key', {min: 2, cache: false}),
       item1 = {key: 'the quick brown fox'},
@@ -289,7 +289,7 @@ describe('TrieSearch', function() {
       assert(f1 !== f2, 'was not the same array.');
     });
   });
-  
+
   describe('TrieSearch::get(...) should work for multiple keys and union the result with an indexField', function() {
     var ts = new TrieSearch(['key', 'key2'], {min: 2, indexField: 'ix'}),
       item1 = {key: 'the quick brown fox', key2: 'jumped', ix: 1},
@@ -305,7 +305,7 @@ describe('TrieSearch', function() {
     it('get(\'the quick\') should return all 4 entries', function() {
       assert(ts.get('the quick').length == 4);
     });
-    
+
     it('get(\'the brown\') should return all 4 entries', function() {
       assert(ts.get('the brown').length == 4);
     });
@@ -313,23 +313,23 @@ describe('TrieSearch', function() {
     it('get(\'the fox\') should return 3 entries', function() {
       assert(ts.get('the fox').length == 3);
     });
-    
+
     it('get(\'fox brown\') should return 3 entries', function() {
       assert(ts.get('fox brown').length == 3);
     });
-    
+
     it('get(\'brown fox\') should return 3 entries', function() {
       assert(ts.get('brown fox').length == 3);
     });
-    
+
     it('get(\'brown z\') should return 4 entries', function() {
       assert(ts.get('brown z').length == 4);
     });
-    
+
     it('get(\'br f\') should return all entries', function() {
       assert(ts.get('br f').length == 4);
     });
-    
+
     it('get(\'jum b c d e f g h\') should return 2 entries, ignoring the shortness of all subsequent words', function() {
       assert(ts.get('jum b c d e f g h').length == 2);
     });
@@ -379,7 +379,7 @@ describe('TrieSearch', function() {
       assert(ts.get('jum b c d e f g h').length == 2);
     });
   });
-  
+
   describe('TrieSearch::add(...) and TrieSearch::get(...) should work for a single item with multiple subphrases', function() {
     var ts = new TrieSearch('key'),
       item = {key: 'blah whatever yeah man'};
@@ -398,32 +398,32 @@ describe('TrieSearch', function() {
       assert.equal(ts.get('bl')[0], item);
       assert.equal(ts.get('bla')[0], item);
       assert.equal(ts.get('blah')[0], item);
-      
+
       assert.equal(ts.get('w')[0], item);
       assert.equal(ts.get('wh')[0], item);
       assert.equal(ts.get('whatever')[0], item);
     });
-    
+
     it('get(\'whatever\') for each subkey should work', function() {
       assert.equal(ts.get('w')[0], item);
       assert.equal(ts.get('what')[0], item);
       assert.equal(ts.get('whatever')[0], item);
     });
-    
+
     it('get(\'yeah\') for each subkey should work', function() {
       assert.equal(ts.get('y')[0], item);
       assert.equal(ts.get('ye')[0], item);
       assert.equal(ts.get('yea')[0], item);
       assert.equal(ts.get('yeah')[0], item);
     });
-    
+
     it('get(\'man\') for each subkey should work', function() {
       assert.equal(ts.get('m')[0], item);
       assert.equal(ts.get('ma')[0], item);
       assert.equal(ts.get('man')[0], item);
     });
   });
-  
+
   describe('TrieSearch::add(...) and TrieSearch::get(...) should work for multiple items', function() {
     var ts = new TrieSearch('key'),
       item1 = {key: 'I am item1!'},
@@ -449,7 +449,7 @@ describe('TrieSearch', function() {
       assert(ts.get('item2').length == 1, 'did not return 1 item!');
     });
   });
-  
+
   describe('TrieSearch::add(...) and TrieSearch::get(...) should work with options.min', function() {
     var ts = new TrieSearch('key', {min: 2}),
       item1 = {key: 'I am item1!'},
@@ -457,7 +457,7 @@ describe('TrieSearch', function() {
 
     ts.add(item1);
     ts.add(item2);
-    
+
     it('add(item1) and add(item2) should build map of nodes', function() {
       assert(ts.root['i'] === undefined, 'I should not exist!');
       assert(ts.root['am'] !== undefined, 'am does not exist');
@@ -469,7 +469,7 @@ describe('TrieSearch', function() {
       assert(ts.get('i').length == 0, 'did not return 0 items!');
       assert(ts.get('item').length == 2, 'did not return 2 items!');
     });
-    
+
     it('get(\'item\') should return 2 items', function() {
       assert(ts.get('item').length == 2, 'did not return 2 items!');
     });
@@ -735,6 +735,38 @@ describe('TrieSearch', function() {
 
       assert(ts.get('What Is')[0] === item2, 'Did not properly match What');
       assert(ts.get('Color Favorite')[0] === item2, 'Did not properly match Is');
+    });
+  });
+
+  describe('TrieSearch::get(...) works with expandMisspellings=true', function() {
+    it('should work with deletions', function() {
+      var ts = new TrieSearch('someValue', {
+          enableMisspellings: true
+        }),
+        item = {someValue: 'hello'},
+        item2 = {someValue: 'what. up arthur!'};
+
+      ts.add(item);
+      ts.add(item2);
+
+      assert(ts.get('.').length === 0, 'Did not properly match .');
+
+      assert(ts.get('h')[0] === item, 'Did not properly match h');
+      assert(ts.get('hello')[0] === item, 'Did not properly match hello');
+      assert(ts.get('helo')[0] === item, 'Did not properly match hlelo');
+      assert(ts.get('hell')[0] === item, 'Did not properly match hell');
+      assert(ts.get('hllo')[0] === item, 'Did not properly match hell');
+
+      assert(ts.get('wht')[0] === item2, 'Did not properly match wht');
+      assert(ts.get('wat')[0] === item2, 'Did not properly match wat');
+
+      assert(ts.get('up')[0] === item2, 'Did not properly match up');
+
+      assert(ts.get('artur')[0] === item2, 'Did not properly match artur');
+      assert(ts.get('artu')[0] === item2, 'Did not properly match artu');
+      assert(ts.get('athur')[0] === item2, 'Did not properly match athur');
+      assert(ts.get('arhur')[0] === item2, 'Did not properly match arhur');
+      assert(ts.get('arthr')[0] === item2, 'Did not properly match arthr');
     });
   });
 });


### PR DESCRIPTION
This is too massive of a performance hit but was a good experiment:

Joshuas-MacBook-Pro:~/dev/trie-search (enable-misspellings-wip u=)$ node performance.js 
-------------- Running enableMisspellings=false --------------
	Search Items Added:  86036
	Trie Node Count:  280206
	Trie Memory Used: 49.44140625 MB
	Time spent Inserting (ms) 555
	Time spent retrieving (ms) 85
-------------- Running enableMisspellings=true --------------
	Search Items Added:  86036
	Trie Node Count:  5770982
	Trie Memory Used: 625.67578125 MB
	Time spent Inserting (ms) 8774
	Time spent retrieving (ms) 1154
