### PR TITLE
Fix/get limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "trie-search",
-  "version": "1.3.0",
+  "version": "1.2.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9,7 +9,7 @@
       "resolved": "https://registry.npmjs.org/hasharray/-/hasharray-1.1.1.tgz",
       "integrity": "sha512-L+WTUz5XcfQyh3652tOEDLL5ZG6MAS+iYqM2K0N9H/z7RpW0rjlFkXLRdqbwqrGCr9korJzyfDD7i7mtwo42wg==",
       "requires": {
-        "jclass": "1.2.1"
+        "jclass": "^1.0.1"
       }
     },
     "jclass": {

--- a/src/TrieSearch.js
+++ b/src/TrieSearch.js
@@ -249,11 +249,18 @@ TrieSearch.prototype = {
       return f(keyArr, node[k]);
     }
   },
+  _getCacheKey: function(phrase, limit){
+    var cacheKey = phrase
+    if(limit) {
+      cacheKey = phrase + "_" + limit
+    }
+    return cacheKey
+  },
   _get: function (phrase, limit) {
     phrase = this.options.ignoreCase ? phrase.toLowerCase() : phrase;
     
     var c, node;
-    if (this.options.cache && (c = this.getCache.get(phrase)))
+    if (this.options.cache && (c = this.getCache.get(this._getCacheKey(phrase, limit))))
       return c.value;
 
     var ret = undefined,
@@ -277,7 +284,8 @@ TrieSearch.prototype = {
 
     if (this.options.cache)
     {
-      this.getCache.add({key: phrase, value: v});
+      var cacheKey = this._getCacheKey(phrase, limit)
+      this.getCache.add({key: cacheKey, value: v});
       this.cleanCache();
     }
 

--- a/test/TrieSearchTest.js
+++ b/test/TrieSearchTest.js
@@ -737,4 +737,36 @@ describe('TrieSearch', function() {
       assert(ts.get('Color Favorite')[0] === item2, 'Did not properly match Is');
     });
   });
+
+  describe('TrieSearch:TrieSearch::get(...) should work with limits', function() {
+    // NOTE: Cache is set to false since we are mixing both limits and without limits
+    var ts = new TrieSearch(null, {cache: false});
+    var obj = {
+      "a": ["data"],
+      "ab": ["data"],
+      "abc": ["data"],
+      "abcd": ["data"],
+      "abcde": ["data"],
+      "abcdef": ["data"],
+    }
+    ts.addFromObject(obj);
+
+    it('Get with limits and get without limits should work properly', function() {
+      var getWithoutLimit = ts.get("a")
+      assert(getWithoutLimit.length === 6, "Expected 6 in without-limit get")
+
+      var getWithLimitResp= ts.get("a", null, 4)
+      assert(getWithLimitResp.length === 4, "Expected 4 in with-limit get")
+    });
+
+    it('Failure case with limits should work properly', function() {
+      var getWithLimit = ts.get("b", null, 4)
+      assert(getWithLimit.length === 0, "Expected 0 in with-limit get")
+    });
+
+    it('A bigger limit value than the actual amount of data must work properly', function() {
+      var getWithLimit = ts.get("a", null, 100)
+      assert(getWithLimit.length === 6, "Expected 6 in with-limit get")
+    });
+  });
 });

--- a/test/TrieSearchTest.js
+++ b/test/TrieSearchTest.js
@@ -739,8 +739,8 @@ describe('TrieSearch', function() {
   });
 
   describe('TrieSearch:TrieSearch::get(...) should work with limits', function() {
-    // NOTE: Cache is set to false since we are mixing both limits and without limits
-    var ts = new TrieSearch(null, {cache: false});
+    // NOTE: Cache is set to true since caching also needs to be tested
+    var ts = new TrieSearch(null, {cache: true});
     var obj = {
       "a": ["data"],
       "ab": ["data"],

--- a/trieGetTest.js
+++ b/trieGetTest.js
@@ -1,0 +1,42 @@
+var TrieSearch = require('./src/TrieSearch');
+var dict = require('./dictionary.json');
+const NUM_ITERATIONS = 100
+
+/**
+ * Function to time a block of code. Returns avg time to execute the given function.
+ * @param {*} f - Function to time
+ * @param {*} count - Number of iterations to continously run the block of code
+ */
+function timeFunction(f, count) {
+    let results = []
+    for (let i = 0; i < count; i++) {
+        let startTime = new Date().getTime()
+        f()
+        let endTime = new Date().getTime()
+        results.push(endTime - startTime)
+    }
+
+    let timeSum = 0
+    results.map((r) => {
+        timeSum += r
+    })
+    return timeSum / count
+}
+
+// Turn off caching
+var ts = new TrieSearch(
+    null,
+    {
+        cache: false,
+    }
+);
+ts.addFromObject(dict);
+console.log('Dictionary loaded into TrieSearch.');
+
+// NOTE: Choosing s since that seems to have the largest number of results - 9950
+let avgTimeWithoutLimit = timeFunction(function () {
+    ts.get('s')
+}, NUM_ITERATIONS)
+
+// Get the average time
+console.log("Avg time - ", avgTimeWithoutLimit)

--- a/trieGetTest.js
+++ b/trieGetTest.js
@@ -33,10 +33,33 @@ var ts = new TrieSearch(
 ts.addFromObject(dict);
 console.log('Dictionary loaded into TrieSearch.');
 
+// Testing without limit
 // NOTE: Choosing s since that seems to have the largest number of results - 9950
 let avgTimeWithoutLimit = timeFunction(function () {
     ts.get('s')
 }, NUM_ITERATIONS)
+console.log("Avg time without-limit \t\t - ", avgTimeWithoutLimit, " ms")
 
-// Get the average time
-console.log("Avg time - ", avgTimeWithoutLimit)
+// Testing with limit
+var avgTimeWithLimit = timeFunction(function () {
+    ts.get('s', null, 10)
+}, NUM_ITERATIONS)
+console.log("Avg time with-limit 10 \t\t - ", avgTimeWithLimit, " ms")
+
+// Testing with limit 100
+var avgTimeWithLimit = timeFunction(function () {
+    ts.get('s', null, 100)
+}, NUM_ITERATIONS)
+console.log("Avg time with-limit 100 \t - ", avgTimeWithLimit, " ms")
+
+// Testing with limit 1000
+var avgTimeWithLimit = timeFunction(function () {
+    ts.get('s', null, 1000)
+}, NUM_ITERATIONS)
+console.log("Avg time with-limit 1000 \t - ", avgTimeWithLimit, " ms")
+
+// Testing with limit 10000
+var avgTimeWithLimit = timeFunction(function () {
+    ts.get('s', null, 10000)
+}, NUM_ITERATIONS)
+console.log("Avg time with-limit 10k \t - ", avgTimeWithLimit, " ms")

--- a/trieGetTest.js
+++ b/trieGetTest.js
@@ -1,3 +1,9 @@
+/**
+ * A performance test file to compare the difference in performance of getting 
+ * from the Trie when using limits. This can be run by 
+ * `node trieGetTest.js`
+ */
+
 var TrieSearch = require('./src/TrieSearch');
 var dict = require('./dictionary.json');
 const NUM_ITERATIONS = 100


### PR DESCRIPTION
Hi,
This PR is is for adding the max-results (or limit as I've named it) functionality in the trie. This somewhat addresses the issue raised in #16. 
Includes unit-tests and performance tests, comparing `get` with and without limit.
I've added limit as the third parameter in the `get` call. 
Also, the cached phrase includes the limit as well, to handle cases when subsequent queries are made with and without limits consecutively.

NOTE: The limit functionality in this PR does not address the sorting issue. This just returns whenever the Hasharray is full. I am not really sure how to do that with the current structure. This is a purely subjective opinion - I think there could be use-cases (like in auto-complete) where speed of response is more important than the order. Therefore, limiting the amount of results from the trie itself could prove more efficient, in cases where the trie is big, say incase of the english dictionary. 

PS: Thank you for this library :)