### PR TITLE
Removed redundant if statement checking options.min and word length

### DIFF
--- a/src/TrieSearch.js
+++ b/src/TrieSearch.js
@@ -235,9 +235,6 @@ TrieSearch.prototype = {
     return keyArr;
   },
   findNode: function (key) {
-    if (this.options.min > 0 && key.length < this.options.min)
-      return [];
-
     return f(this.keyToArr(key), this.root);
 
     function f(keyArr, node) {


### PR DESCRIPTION
### Issue
"if" statement in `_get` function checks `this.options.min` and `word[w].length` meaning `findNode` function is not called when statement is `true` due to `continue;`.

<img width="609" alt="Screen Shot 2021-04-05 at 12 46 25 PM" src="https://user-images.githubusercontent.com/46350781/113612403-06566a80-960d-11eb-803c-d1b4ad4b023d.png">

`word[w]` is passed to `findNode` function and redundant "if" statement will never evaluate to `true` since `this.options.min` and `word[w].length` have already been checked.

<img width="627" alt="Screen Shot 2021-04-05 at 12 51 01 PM" src="https://user-images.githubusercontent.com/46350781/113612899-aa401600-960d-11eb-9418-df5339056e0c.png">

Note: This assumes `findNode` function is only used internally because its use externally is not specified in the README or test code like the `map` function is.

### Testing
I confirmed "if" statement never evaluates to true by running tests and checking for console output.

Also ran tests after deleting "if" statement and all passed:

<img width="699" alt="Screen Shot 2021-04-05 at 12 30 21 PM" src="https://user-images.githubusercontent.com/46350781/113614879-5a168300-9610-11eb-9257-bed1e693a666.png">
