### PR TITLE
Don't include test files into bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,7 @@
   },
   "files": [
     "src",
-    "test",
-    "index.js",
-    "performance.js",
-    "dictionary.json"
+    "index.js"
   ],
   "keywords": [
     "trie",


### PR DESCRIPTION
Hello.
I am using this package in few projects.
When improving the size of my node_modules directory, I have found that `trie-search` is about ~9Mb. 
After checking a bit I have figured out that tests files (especially `dictionary.json`) are included into package node_modules.

This eventually impacts the install time for development and increasing memory/time usage during CI builds. 

