### PR TITLE
To include type definitions  when publishing as npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "A trie implementation that maps keys to objects for rapid retrieval by phrases. Most common use will be for typeahead searches.",
   "version": "1.4.1",
   "main": "index.js",
+  "types": "index.d.ts",
   "url": "https://github.com/joshjung/trie-search",
   "homepage": "https://github.com/joshjung/trie-search",
   "email": "joshua.p.jung@gmail.com",
@@ -20,6 +21,7 @@
   },
   "files": [
     "src",
+    "index.d.ts",
     "index.js"
   ],
   "keywords": [


### PR DESCRIPTION
Hello.
Thanks for the great project!
Is there any reason not to include type definitions when publishing as npm package?
If there is no special reason, I would be happy to include type definitions as a user.