### PR TITLE
Fix remove to be able to handle capitalized letters

### DIFF
--- a/src/TrieSearch.js
+++ b/src/TrieSearch.js
@@ -83,6 +83,9 @@ TrieSearch.prototype = {
       if (!val) continue;
 
       val = val.toString();
+      if (this.options.ignoreCase) {
+        val = val.toLowerCase();
+      }
 
       var expandedValues = this.expandString(val);
 
@@ -96,6 +99,10 @@ TrieSearch.prototype = {
   remove: function (phrase, keyFields) {
     if (!phrase) return;
     phrase = phrase.toString();
+    if (this.options.ignoreCase) {
+      phrase = phrase.toLowerCase();
+    }
+
     keyFields = keyFields || this.keyFields;
     keyFields = keyFields instanceof Array ? keyFields : [keyFields];
 
@@ -116,7 +123,10 @@ TrieSearch.prototype = {
 
     if (!word.length) {
       node.value = node.value.filter(
-        (item) => !keyFields.some((key) => item[key] === phrase),
+          (item) => !keyFields.some((key) => {
+            var toCompare = this.options.ignoreCase ? item[key].toLowerCase() : item[key];
+            return toCompare === phrase
+          }),
       );
       if (!node.value.length) {
         delete node.value;

--- a/test/trie-search.test.ts
+++ b/test/trie-search.test.ts
@@ -955,5 +955,35 @@ describe('TrieSearch', function() {
       ts.remove(keyValue1);
       expect(ts.search(keyValue1).length).toEqual(1);
     });
+
+    it('should remove item if ignoreCase is true and capitalized letters are present', function () {
+      type Item = {
+        key: string
+      }
+      const ts: TrieSearch<any> = new TrieSearch<any>(['key'], {
+          ignoreCase: true,
+        }),
+        item: Item = {key: 'John'};
+
+      ts.add(item)
+      expect(ts.get(item.key)[0]).toBe(item);
+      ts.remove(item.key);
+      expect(ts.get(item.key).length).toBe(0);
+    });
+
+    it('should remove a similar item if only uppercase/lowercase are changed', function () {
+      type Item = {
+        key: string
+      }
+      const ts: TrieSearch<any> = new TrieSearch<any>(['key'], {
+          ignoreCase: true,
+        }),
+        item: Item = {key: 'John'};
+
+      ts.add(item)
+      expect(ts.get(item.key)[0]).toBe(item);
+      ts.remove(item.key.toLowerCase());
+      expect(ts.get(item.key).length).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
I noticed an issue with the remove method when strings with capitalized letters where present and ignoreCase was true. 
I adapted it to work how I expect it to work, but definitely  not the only solution and probably not optimally fast.