### PR TITLE
Remove redundant `toLowerCase` call (again)

### DIFF
--- a/src/TrieSearch.js
+++ b/src/TrieSearch.js
@@ -106,9 +106,6 @@ TrieSearch.prototype = {
       if (!val) continue;
 
       val = val.toString();
-      if (this.options.ignoreCase) {
-        val = val.toLowerCase();
-      }
 
       // Given a string like "Björne" this will return ["Björne", "Bjorne"] when using the default
       // expand regex so that the vowel 'o' still returns the result when searching.


### PR DESCRIPTION
Looks like a regression of the bug fixed in #22.

Need to add tests for this case...