### PR TITLE
Remove redundant `toLowerCase` call (again)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ trie search.
 
 `options.min`: Minimum length of a key to store and search. By default this is 1
 
-`options.ingoreCase`: Ignore case of characters when searching
+`options.ignoreCase`: A boolean that controls case sensitivity. When `true` (the default), all keys are indexed in lowercase and all searches are performed in lowercase, making the trie case-insensitive. When `false`, the original casing of keys is preserved during indexing, and lookups become case-sensitive. 
+
+> **Note:** This option is applied *after* a key has been tokenized by `splitOnRegEx`. This allows you to, for example, split a `camelCase` string by its capital letters and then treat each resulting word case-insensitively.
 
 `idFieldOrFunction`: Used to determine a unique string id for each inserted item, especially used by the reducer. By
 default this is a function that uses the provided keyFields to build up an md5 unique id that is stored on each item

--- a/src/TrieSearch.js
+++ b/src/TrieSearch.js
@@ -106,9 +106,6 @@ TrieSearch.prototype = {
       if (!val) continue;
 
       val = val.toString();
-      if (this.options.ignoreCase) {
-        val = val.toLowerCase();
-      }
 
       // Given a string like "Björne" this will return ["Björne", "Bjorne"] when using the default
       // expand regex so that the vowel 'o' still returns the result when searching.

--- a/test/trie-search.test.ts
+++ b/test/trie-search.test.ts
@@ -920,7 +920,7 @@ describe('TrieSearch', function() {
     });
   });
 
-  describe('TrieSearch::map(...) works with RegEx with positive lookahead (e.g. split on capital letters)', function() {
+  describe('TrieSearch::map(...) and TrieSearch::add(...) work with RegEx with positive lookahead (e.g. split on capital letters)', function() {
     it('should not error', function() {
       expect(() => {
         const ts : TrieSearch<any> = new TrieSearch<any>('key', {
@@ -988,6 +988,24 @@ describe('TrieSearch', function() {
 
       expect(ts.search('Hello')[0]).toBe(item);
       expect(ts.search('Up')[0]).toBe(item2);
+    });
+
+    it('should handle camelCase indexing with ignoreCase', function() {
+      const trie = new TrieSearch('key', {
+        splitOnRegEx: /[\s]|(?=[A-Z])/,
+        splitOnGetRegEx: false,
+      });
+
+      const item1 = { key: 'fooBar', value: 123 };
+      const item2 = { key: 'foo Bar', value: 456 };
+
+      trie.add(item1);
+      trie.add(item2);
+
+      const results = trie.search('BAR');
+      expect(results.length).toEqual(2);
+      expect(results).toContain(item1);
+      expect(results).toContain(item2);
     });
   });
 


### PR DESCRIPTION
Looks like a regression of the bug fixed in #22.
Added a test case to cover this regression.
